### PR TITLE
Allow users to provide an ExecutionContext

### DIFF
--- a/app/com/github/fkoehler/play/compressor/CompressorFilter.scala
+++ b/app/com/github/fkoehler/play/compressor/CompressorFilter.scala
@@ -19,8 +19,7 @@ import play.api.http.HeaderNames._
 import play.api.http.{ HttpEntity, HttpProtocol }
 import play.api.mvc._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * Base implementation of a filter which makes it possible to compress either HTML or XML with the
@@ -50,6 +49,11 @@ abstract class CompressorFilter[C <: Compressor] extends Filter {
    * Materializer for the Filter.
    */
   override implicit val mat: Materializer
+
+  /**
+   * ExecutionContext used by the Filter.
+   */
+  implicit val executionContext: ExecutionContext
 
   /**
    * Apply the filter.

--- a/app/com/github/fkoehler/play/htmlcompressor/HTMLCompressorFilter.scala
+++ b/app/com/github/fkoehler/play/htmlcompressor/HTMLCompressorFilter.scala
@@ -20,6 +20,8 @@ import play.api.inject.Module
 import play.api.mvc._
 import play.api.{ Configuration, Environment, Mode }
 
+import scala.concurrent.ExecutionContext
+
 /**
  * Uses Google's HTML Processor to compress the HTML code of a response.
  */
@@ -80,6 +82,12 @@ class DefaultHTMLCompressorFilter @Inject() (val configuration: Configuration, e
     )
     c
   }
+
+  /**
+   * ExecutionContext used by the Filter.
+   */
+  override implicit val executionContext: ExecutionContext =
+    ExecutionContext.global
 }
 
 /**

--- a/app/com/github/fkoehler/play/xmlcompressor/XMLCompressorFilter.scala
+++ b/app/com/github/fkoehler/play/xmlcompressor/XMLCompressorFilter.scala
@@ -19,6 +19,8 @@ import play.api.inject.Module
 import play.api.mvc._
 import play.api.{ Configuration, Environment }
 
+import scala.concurrent.ExecutionContext
+
 /**
  * Uses Google's XML Processor to compress the XML code of a response.
  */
@@ -61,6 +63,12 @@ class DefaultXMLCompressorFilter @Inject() (val configuration: Configuration, va
     )
     c
   }
+
+  /**
+   * ExecutionContext used by the Filter.
+   */
+  override implicit val executionContext: ExecutionContext =
+    ExecutionContext.global
 }
 
 /**

--- a/test/com/github/fkoehler/play/htmlcompressor/fixtures/Filters.scala
+++ b/test/com/github/fkoehler/play/htmlcompressor/fixtures/Filters.scala
@@ -20,6 +20,8 @@ import play.api.http.HttpFilters
 import play.api.mvc.EssentialFilter
 import play.filters.gzip.GzipFilter
 
+import scala.concurrent.ExecutionContext
+
 /**
  * A custom HTML compressor filter.
  */
@@ -38,6 +40,9 @@ class CustomHTMLCompressorFilter @Inject() (val configuration: Configuration, en
     c.setRemoveHttpsProtocol(true)
     c
   }
+
+  override implicit val executionContext: ExecutionContext =
+    ExecutionContext.global
 }
 
 /**

--- a/test/com/github/fkoehler/play/htmlcompressor/fixtures/java/CustomHTMLCompressorFilter.java
+++ b/test/com/github/fkoehler/play/htmlcompressor/fixtures/java/CustomHTMLCompressorFilter.java
@@ -19,6 +19,8 @@ import play.api.Configuration;
 
 import javax.inject.Inject;
 
+import scala.concurrent.ExecutionContext;
+
 /**
  * Custom implementation of the HTML compressor filter.
  */
@@ -27,12 +29,14 @@ public class CustomHTMLCompressorFilter extends HTMLCompressorFilter {
     private Configuration configuration;
     private Environment environment;
     private Materializer mat;
+    private ExecutionContext executionContext;
 
     @Inject
-    public CustomHTMLCompressorFilter(Configuration configuration, Environment environment, Materializer mat) {
+    public CustomHTMLCompressorFilter(Configuration configuration, Environment environment, Materializer mat, ExecutionContext executionContext) {
         this.configuration = configuration;
         this.environment = environment;
         this.mat = mat;
+        this.executionContext = executionContext;
     }
 
     @Override
@@ -58,5 +62,10 @@ public class CustomHTMLCompressorFilter extends HTMLCompressorFilter {
     @Override
     public Materializer mat() {
         return mat;
+    }
+
+    @Override
+    public ExecutionContext executionContext() {
+        return executionContext;
     }
 }

--- a/test/com/github/fkoehler/play/xmlcompressor/fixtures/Filters.scala
+++ b/test/com/github/fkoehler/play/xmlcompressor/fixtures/Filters.scala
@@ -19,6 +19,8 @@ import play.api.http.HttpFilters
 import play.api.mvc.EssentialFilter
 import play.filters.gzip.GzipFilter
 
+import scala.concurrent.ExecutionContext
+
 /**
  * A custom XML compressor filter.
  */
@@ -28,6 +30,9 @@ class CustomXMLCompressorFilter @Inject() (val configuration: Configuration, val
     c.setRemoveComments(false)
     c
   }
+
+  override implicit val executionContext: ExecutionContext =
+    ExecutionContext.global
 }
 
 /**

--- a/test/com/github/fkoehler/play/xmlcompressor/fixtures/java/CustomXMLCompressorFilter.java
+++ b/test/com/github/fkoehler/play/xmlcompressor/fixtures/java/CustomXMLCompressorFilter.java
@@ -17,6 +17,8 @@ import play.api.Configuration;
 
 import javax.inject.Inject;
 
+import scala.concurrent.ExecutionContext;
+
 /**
  * Custom implementation of the XML compressor filter.
  */
@@ -24,11 +26,13 @@ public class CustomXMLCompressorFilter extends XMLCompressorFilter {
 
     private Configuration configuration;
     private Materializer mat;
+    private ExecutionContext executionContext;
 
     @Inject
-    public CustomXMLCompressorFilter(Configuration configuration, Materializer mat) {
+    public CustomXMLCompressorFilter(Configuration configuration, Materializer mat, ExecutionContext executionContext) {
         this.configuration = configuration;
         this.mat = mat;
+        this.executionContext = executionContext;
     }
 
     @Override
@@ -47,5 +51,10 @@ public class CustomXMLCompressorFilter extends XMLCompressorFilter {
     @Override
     public Materializer mat() {
         return mat;
+    }
+
+    @Override
+    public ExecutionContext executionContext() {
+        return executionContext;
     }
 }


### PR DESCRIPTION
Since compression is a potentially expensive operation, it can be useful to have control over which `ExecutionContext` it executes on. These changes add support for providing an `ExecutionContext` via a new abstract `val executionContext` in the base `CompressorFilter`. The `Default<HTML|XML>CompressorFilter`s will continue using `ExecutionContext.global`.